### PR TITLE
fixed rando being incorrectly evaluated in tests

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -4,13 +4,12 @@ const spies = require( 'chai-spies' );
 const nock = require( 'nock' );
 chai.use( spies );
 
+const rando = Math.ceil( Math.random() * 1000 )
+
 describe( "submitData()", () => {
-  let rando
   let xhr, requests
   beforeEach( function () {
     window.fetch = require( 'node-fetch' );
-
-    rando = Math.ceil( Math.random() * 1000 )
 
 
 


### PR DESCRIPTION
For whatever reason, the rando variable seems to evaluate differently in the beforeEach function and inside the expect for the second test. I couldn't determine why but by making it consistent between tests it allowed them to pass.